### PR TITLE
TestMemoryCallbacksRealServer failing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1263,7 +1263,7 @@ if(WIN32)
 
   # Link required libraries for USE_WIN32_CRYPTO or USE_SCHANNEL
   if(USE_WIN32_CRYPTO OR USE_SCHANNEL)
-    list(APPEND CURL_LIBS "advapi32" "crypt32" "shlwapi")
+    list(APPEND CURL_LIBS "advapi32" "crypt32")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1263,7 +1263,7 @@ if(WIN32)
 
   # Link required libraries for USE_WIN32_CRYPTO or USE_SCHANNEL
   if(USE_WIN32_CRYPTO OR USE_SCHANNEL)
-    list(APPEND CURL_LIBS "advapi32" "crypt32")
+    list(APPEND CURL_LIBS "advapi32" "crypt32" "shlwapi")
   endif()
 endif()
 

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -21,6 +21,10 @@
  * KIND, either express or implied.
  *
  ***************************************************************************/
+#if defined(WIN32)
+  #include <shlwapi.h>
+#endif
+
 #include "curl_setup.h"
 
 #if defined(WIN32)
@@ -63,11 +67,35 @@ typedef union {
   unsigned short       *tbyte_ptr;
   const unsigned short *const_tbyte_ptr;
 } xcharp_u;
+#define curlx_unicodefree(ptr)                          \
+  do {                                                  \
+    (ptr) = NULL;                                     \
+  } while(0)
 
 #else
+#ifdef WIN32
 
-#define curlx_convert_UTF8_to_tchar(ptr) (strdup)(ptr)
-#define curlx_convert_tchar_to_UTF8(ptr) (strdup)(ptr)
+#define curlx_convert_UTF8_to_tchar(ptr) (StrDupA)(ptr)
+#define curlx_convert_tchar_to_UTF8(ptr) (StrDupA)(ptr)
+
+#define curlx_unicodefree(ptr)                          \
+  do {                                                  \
+    if(ptr) {                                           \
+      (LocalFree)(ptr);                                      \
+      (ptr) = NULL;                                     \
+    }                                                   \
+  } while(0)
+#else 
+  #define curlx_convert_UTF8_to_tchar(ptr) (strdup)(ptr)
+  #define curlx_convert_tchar_to_UTF8(ptr) (strdup)(ptr)
+  #define curlx_unicodefree(ptr)                          \
+    do {                                                  \
+      if(ptr) {                                           \
+        (free)(ptr);                                      \
+        (ptr) = NULL;                                     \
+      }                                                   \
+    } while(0)
+#endif
 
 typedef union {
   char                *tchar_ptr;
@@ -78,12 +106,5 @@ typedef union {
 
 #endif /* UNICODE && WIN32 */
 
-#define curlx_unicodefree(ptr)                          \
-  do {                                                  \
-    if(ptr) {                                           \
-      (free)(ptr);                                      \
-      (ptr) = NULL;                                     \
-    }                                                   \
-  } while(0)
 
 #endif /* HEADER_CURL_MULTIBYTE_H */

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -21,11 +21,8 @@
  * KIND, either express or implied.
  *
  ***************************************************************************/
-#if defined(WIN32)
-  #include <shlwapi.h>
-#endif
-
 #include "curl_setup.h"
+#include "curl_memory.h"
 
 #if defined(WIN32)
 
@@ -67,35 +64,11 @@ typedef union {
   unsigned short       *tbyte_ptr;
   const unsigned short *const_tbyte_ptr;
 } xcharp_u;
-#define curlx_unicodefree(ptr)                          \
-  do {                                                  \
-    (ptr) = NULL;                                     \
-  } while(0)
 
 #else
-#ifdef WIN32
 
-#define curlx_convert_UTF8_to_tchar(ptr) (StrDupA)(ptr)
-#define curlx_convert_tchar_to_UTF8(ptr) (StrDupA)(ptr)
-
-#define curlx_unicodefree(ptr)                          \
-  do {                                                  \
-    if(ptr) {                                           \
-      (LocalFree)(ptr);                                      \
-      (ptr) = NULL;                                     \
-    }                                                   \
-  } while(0)
-#else 
-  #define curlx_convert_UTF8_to_tchar(ptr) (strdup)(ptr)
-  #define curlx_convert_tchar_to_UTF8(ptr) (strdup)(ptr)
-  #define curlx_unicodefree(ptr)                          \
-    do {                                                  \
-      if(ptr) {                                           \
-        (free)(ptr);                                      \
-        (ptr) = NULL;                                     \
-      }                                                   \
-    } while(0)
-#endif
+#define curlx_convert_UTF8_to_tchar(ptr) strdup(ptr)
+#define curlx_convert_tchar_to_UTF8(ptr) strdup(ptr)
 
 typedef union {
   char                *tchar_ptr;
@@ -106,5 +79,12 @@ typedef union {
 
 #endif /* UNICODE && WIN32 */
 
+#define curlx_unicodefree(ptr)                          \
+  do {                                                  \
+    if(ptr) {                                           \
+      free(ptr);                                      \
+      (ptr) = NULL;                                     \
+    }                                                   \
+  } while(0)
 
 #endif /* HEADER_CURL_MULTIBYTE_H */


### PR DESCRIPTION
Memory test failing when `ENABLE_UNICODE` is `OFF`. Solution: use `StrDupA`/`LocalFree` instead of `strdup`/`free`. 
Didn't change `malloc`s in the `schannel.c` though (we didn't patch those in `bidstack` too: https://github.com/bidstack-group/curl/blob/bidstack/lib/vtls/schannel.c), should I?
Also, I don't know if `ENABLE_UNICODE` branch should be fixed now or whenever we decide to use `ENABLE_UNICODE`?

Failing build:
https://dev.azure.com/bidstack/bidstack-cpp-sdk/_build/results?buildId=18392&view=logs&j=070d47b6-0f95-58e9-0f6c-2e08699c6fb5&t=ca4e29bc-3ffe-579e-1703-ae2166e85103

Interesting that it's only the debug build that's failing 🤔 am I missing something?